### PR TITLE
Use the latin abbreviation of "et al"

### DIFF
--- a/locales-nl-NL.xml
+++ b/locales-nl-NL.xml
@@ -36,7 +36,7 @@
       <multiple>drukken</multiple>
     </term>
     <term name="edition" form="short">dr.</term>
-    <term name="et-al">e.a.</term>
+    <term name="et-al">et al.</term>
     <term name="forthcoming">in voorbereiding</term>
     <term name="from">van</term>
     <term name="ibid">ibid.</term>


### PR DESCRIPTION
We do not translate the standard term "et al." into Dutch.